### PR TITLE
Rename variables to standard namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.molecule
+.vagrant

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A pre-existing CA certificate keypair must exist in a variable file in the
 following format:
 
 ```yaml
-certificate_authority:
+openssl_node_certificate_authority:
     arbitrary_ca_name:
       pub: >
         asdiaodadiadoaidapodiaodadi
@@ -27,13 +27,11 @@ certificate_authority:
 Here is the rest of the available variables:
 
 ```yaml
-just_ca_pub: false
+openssl_node_only_ca: false
 openssl_node_bit_length: 4096
 openssl_node_name: "{{ ansible_fqdn }}"
 openssl_node_expiration: 365
-
-## should change the following for production
-openssl_node_ca_name: "arbitrary_ca_name"
+openssl_node_ca_name: "name_of_ca_cert" # see `openssl_node_certificate_authority`
 openssl_node_ca_creds: "test_ca"
 
 openssl_node:
@@ -41,7 +39,7 @@ openssl_node:
   bit_length: "{{ openssl_node_bit_length }}"
   pub_dst: /etc/ssl/certs
   priv_dst: /etc/ssl/private
-  local_tmp: ./tmp
+  local_tmp: "./tmp/{{ ansible_fqdn }}"
 
 openssl_node_pkgs:
   - openssl
@@ -49,8 +47,7 @@ openssl_node_pkgs:
 openssl_node_ca:
   use: default_ca_name
 
-# Should also change for production
-ca_cert:
+openssl_ca_cert_details:
   city: San Francisco
   state: CA
   country: US
@@ -58,9 +55,17 @@ ca_cert:
   ou: DevOps
   email: sysadmin@freedom.press
 
-ca_cert_sign:
-  ca_pub_key: "{{ certificate_authority[openssl_node_ca_name].pub }}"
-  ca_priv_key: "{{ certificate_authority[openssl_node_ca_name].private }}"
+# Swap in your CA cert here and stick in an ansible vault
+openssl_node_certificate_authority:
+  name_of_ca_cert:
+    pub: |
+      [ .............. ]
+    private: |
+      [ .............. ]
+
+openssl_node_ca_cert_sign:
+  ca_pub_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].pub }}"
+  ca_priv_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].private }}"
 ```
 
 License

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+roles_path = ../
+retry_files_enabled = False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-just_ca_pub: false
+openssl_node_only_ca: false
 openssl_node_bit_length: 4096
 openssl_node_name: "{{ ansible_fqdn }}"
 openssl_node_expiration: 365
@@ -19,7 +19,7 @@ openssl_node_pkgs:
 openssl_node_ca:
   use: default_ca_name
 
-ca_cert:
+openssl_ca_cert_details:
   city: San Francisco
   state: CA
   country: US
@@ -30,7 +30,7 @@ ca_cert:
 # This is a NON-PRODUCTION Test CA utilized for testing purposes.
 # In production you should have these values stored in your ansible
 # vault. Password is `test_ca` for the encrypted private key below.
-certificate_authority:
+openssl_node_certificate_authority:
   testca_freedom_press:
     pub: |
       -----BEGIN CERTIFICATE-----
@@ -119,6 +119,6 @@ certificate_authority:
       3iM=
       -----END ENCRYPTED PRIVATE KEY-----
 
-ca_cert_sign:
-  ca_pub_key: "{{ certificate_authority[openssl_node_ca_name].pub }}"
-  ca_priv_key: "{{ certificate_authority[openssl_node_ca_name].private }}"
+openssl_node_ca_cert_sign:
+  ca_pub_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].pub }}"
+  ca_priv_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].private }}"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,21 @@
+---
+ansible:
+  verbose: vv
+  diff: yes
+  config_file: ansible.cfg
+
+vagrant:
+  platforms:
+    - name: jessie64
+      box: debian/jessie64
+
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+
+  instances:
+    - name: randomserver
+      ansible_groups:
+        - ssl

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Distribute public CA and generate server key-pair
+  hosts: all
+  gather_facts: yes
+  become: yes
+  roles:
+    - role: ansible-role-openssl-node
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,12 @@
     path: "{{ item }}"
     get_checksum: false
   with_items: ["{{ privkey_dst }}", "{{ pubkey_dst }}"]
-  register: openssl_certs
+  register: openssl_certs_stat
 
 - name: Lay-down public CA key
   copy:
     dest: "/usr/local/share/ca-certificates/{{ openssl_node_ca_name }}.crt"
-    content: "{{ ca_cert_sign.ca_pub_key }}"
+    content: "{{ openssl_node_ca_cert_sign.ca_pub_key }}"
   register: copy_ca_certs
 
 - name: Update system CA store
@@ -21,13 +21,13 @@
   when: copy_ca_certs.changed
 
 - include: packages.yml
-  when: (not openssl_certs.results[0].stat.exists or
-        not openssl_certs.results[1].stat.exists) and
-        not just_ca_pub
+  when: (not openssl_certs_stat.results[0].stat.exists or
+        not openssl_certs_stat.results[1].stat.exists) and
+        not openssl_node_only_ca
   tags: ['packages']
 
 - include: signed-cert.yml
-  when: (not openssl_certs.results[0].stat.exists or
-        not openssl_certs.results[1].stat.exists) and
-        not just_ca_pub
+  when: (not openssl_certs_stat.results[0].stat.exists or
+        not openssl_certs_stat.results[1].stat.exists) and
+        not openssl_node_only_ca
   tags: ['generate']

--- a/tasks/signed-cert.yml
+++ b/tasks/signed-cert.yml
@@ -25,7 +25,7 @@
 - name: Temporarily expand CA cert
   local_action:
     module: copy
-    content: "{{ ca_cert_sign[item] }}"
+    content: "{{ openssl_node_ca_cert_sign[item] }}"
     dest: "{{ openssl_node.local_tmp }}/{{ item }}"
   become: no
   with_items: ['ca_pub_key', 'ca_priv_key']

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -76,28 +76,28 @@ string_mask = utf8only
 
 [ req_distinguished_name ]
 countryName			= Country Name (2 letter code)
-countryName_default		= {{ ca_cert.country }}
+countryName_default		= {{ openssl_ca_cert_details.country }}
 countryName_min			= 2
 countryName_max			= 2
 
 stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= {{ ca_cert.state }}
+stateOrProvinceName_default	= {{ openssl_ca_cert_details.state }}
 
 localityName			= Locality Name (eg, city)
-localityName_default		= {{ ca_cert.city }}
+localityName_default		= {{ openssl_ca_cert_details.city }}
 
 0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= {{ ca_cert.org }}
+0.organizationName_default	= {{ openssl_ca_cert_details.org }}
 
 organizationalUnitName		= Organizational Unit Name (eg, section)
-organizationalUnitName_default	= {{ ca_cert.ou }}
+organizationalUnitName_default	= {{ openssl_ca_cert_details.ou }}
 
 commonName			= Common Name (e.g. server FQDN or YOUR name)
 commonName_max			= 64
 
 emailAddress			= Email Address
 emailAddress_max		= 64
-emailAddress_default		= {{ ca_cert.email }}
+emailAddress_default		= {{ openssl_ca_cert_details.email }}
 
 [ req_attributes ]
 challengePassword		= A challenge password


### PR DESCRIPTION
This closes issue #1 to standardize variable names and ensure they are all
prepended with `openssl_node_`.