### PR TITLE
Refactor role to support CRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,32 @@ openssl_node_certificate_authority:
 Here is the rest of the available variables:
 
 ```yaml
+---
 openssl_node_only_ca: false
 openssl_node_bit_length: 4096
 openssl_node_name: "{{ ansible_fqdn }}"
 openssl_node_expiration: 365
-openssl_node_ca_name: "name_of_ca_cert" # see `openssl_node_certificate_authority`
+openssl_node_ca_name: "testca_freedom_press"
 openssl_node_ca_creds: "test_ca"
+
+openssl_node_pub_ca_dir: /usr/local/share/ca-certificates/
+
+# If you are using this role just for cert signing without revocation needs you
+# dont have to maintain those locally and can purge the private key from the
+# system post CSR signature
+openssl_node_ca_destroy: true
 
 openssl_node:
   name: "{{ openssl_node_name }}"
   bit_length: "{{ openssl_node_bit_length }}"
   pub_dst: /etc/ssl/certs
   priv_dst: /etc/ssl/private
-  local_tmp: "./tmp/{{ ansible_fqdn }}"
+  local_ca_dir: "./tmp/{{ ansible_fqdn }}"
+
+openssl_node_conf: "{{ openssl_node.local_ca_dir }}/openssl.cnf"
 
 openssl_node_pkgs:
+  - ca-certificates
   - openssl
 
 openssl_node_ca:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,9 @@ openssl_node:
   bit_length: "{{ openssl_node_bit_length }}"
   pub_dst: /etc/ssl/certs
   priv_dst: /etc/ssl/private
-  local_tmp: "./tmp/{{ ansible_fqdn }}"
+  local_ca_dir: "./tmp/{{ ansible_fqdn }}"
+
+openssl_node_conf: "{{ openssl_node.local_ca_dir }}/openssl.cnf"
 
 openssl_node_pkgs:
   - ca-certificates

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,11 @@ openssl_node_ca_creds: "test_ca"
 
 openssl_node_pub_ca_dir: /usr/local/share/ca-certificates/
 
+# If you are using this role just for cert signing without revocation needs you
+# dont have to maintain those locally and can purge the private key from the
+# system post CSR signature
+openssl_node_ca_destroy: true
+
 openssl_node:
   name: "{{ openssl_node_name }}"
   bit_length: "{{ openssl_node_bit_length }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ openssl_node_expiration: 365
 openssl_node_ca_name: "testca_freedom_press"
 openssl_node_ca_creds: "test_ca"
 
+openssl_node_pub_ca_dir: /usr/local/share/ca-certificates/
+
 openssl_node:
   name: "{{ openssl_node_name }}"
   bit_length: "{{ openssl_node_bit_length }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Lay-down public CA key
   copy:
     dest: "{{ openssl_node_pub_ca_dir }}/{{ openssl_node_ca_name }}.crt"
-    content: "{{ ca_cert_sign.ca_pub_key }}"
+    content: "{{ openssl_node_ca_cert_sign.ca_pub_key }}"
   register: copy_ca_certs
 
 - name: Update system CA store

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Update system CA store
   command: update-ca-certificates
   when:
-    - copy_ca_certs.changed
+    - copy_ca_certs|changed
     - openssl_node_pub_ca_dir == "/usr/local/share/ca-certificates/"
 
 - include: signed-cert.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,13 +15,15 @@
 
 - name: Lay-down public CA key
   copy:
-    dest: "/usr/local/share/ca-certificates/{{ openssl_node_ca_name }}.crt"
-    content: "{{ openssl_node_ca_cert_sign.ca_pub_key }}"
+    dest: "{{ openssl_node_pub_ca_dir }}/{{ openssl_node_ca_name }}.crt"
+    content: "{{ ca_cert_sign.ca_pub_key }}"
   register: copy_ca_certs
 
 - name: Update system CA store
   command: update-ca-certificates
-  when: copy_ca_certs.changed
+  when:
+    - copy_ca_certs.changed
+    - openssl_node_pub_ca_dir == "/usr/local/share/ca-certificates/"
 
 - include: signed-cert.yml
   when: (not openssl_certs_stat.results[0].stat.exists or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
 - set_fact:
     privkey_dst: "{{ openssl_node.priv_dst }}/{{ openssl_node.name }}-key.pem"
     pubkey_dst: "{{ openssl_node.pub_dst }}/{{ openssl_node.name }}.pem"
+  tags: always
 
 - name: Check if certs already exists
   stat:
@@ -12,6 +13,7 @@
     get_checksum: false
   with_items: ["{{ privkey_dst }}", "{{ pubkey_dst }}"]
   register: openssl_certs_stat
+  tags: always
 
 - name: Lay-down public CA key
   copy:

--- a/tasks/signed-cert.yml
+++ b/tasks/signed-cert.yml
@@ -33,7 +33,7 @@
 - name: Expand CA certs
   local_action:
     module: copy
-    content: "{{ ca_cert_sign[item.key_name] }}"
+    content: "{{ openssl_node_ca_cert_sign[item.key_name] }}"
     dest: "{{ item.dest }}"
   become: no
   with_items:

--- a/tasks/signed-cert.yml
+++ b/tasks/signed-cert.yml
@@ -70,4 +70,5 @@
 - name: Clean-up
   shell: "shred -u -z {{ openssl_node.local_tmp }}/*"
   delegate_to: localhost
+  when: openssl_node_ca_destroy
   become: no

--- a/tasks/signed-cert.yml
+++ b/tasks/signed-cert.yml
@@ -1,40 +1,52 @@
 ---
 - set_fact:
-    certconf_tmp: "{{ ansible_env.TMPDIR | default('/tmp') }}/openssl_node.cnf"
     csr: "{{openssl_node.name}}-req.csr"
     pub_key: "/tmp/{{openssl_node.name}}-pub.pem"
+    remote_certconf_temp: "/tmp/openssl.cnf"
+  tags: always
 
 - name: Spin out remote openssl conf
   template:
     src: openssl.cnf.j2
-    dest: "{{ certconf_tmp }}"
+    dest: "{{ remote_certconf_temp }}"
 
-- name: Ensure local tmp exists
+- name: Ensure local CA dirs exists
   local_action:
     module: file
     state: directory
-    path: "{{ openssl_node.local_tmp }}"
+    path: "{{ item }}"
+  with_items:
+    - "{{ openssl_node.local_ca_dir }}"
+    - "{{ openssl_node.local_ca_dir }}/certs"
+    - "{{ openssl_node.local_ca_dir }}/newcerts"
+    - "{{ openssl_node.local_ca_dir }}/private"
+    - "{{ openssl_node.local_ca_dir }}/csr"
   become: no
 
-- name: Spin out local openssl conf
-  fetch:
-    src: "{{ certconf_tmp }}"
-    dest: "{{ certconf_tmp }}"
-    flat: yes
+- name: Spin out local openssl conf if doesnt exist
+  template:
+    src: openssl.cnf.j2
+    dest: "{{ openssl_node_conf }}"
+    force: no
+  delegate_to: localhost
 
-- name: Temporarily expand CA cert
+- name: Expand CA certs
   local_action:
     module: copy
-    content: "{{ openssl_node_ca_cert_sign[item] }}"
-    dest: "{{ openssl_node.local_tmp }}/{{ item }}"
+    content: "{{ ca_cert_sign[item.key_name] }}"
+    dest: "{{ item.dest }}"
   become: no
-  with_items: ['ca_pub_key', 'ca_priv_key']
+  with_items:
+    - key_name: 'ca_pub_key'
+      dest: "{{ openssl_node.local_ca_dir }}/cacert.pem"
+    - key_name: 'ca_priv_key'
+      dest: "{{ openssl_node.local_ca_dir }}/private/cakey.pem"
   no_log: true
 
 - name: create CSR req
   command: >
     openssl req -new -nodes -out /tmp/{{ csr }}
-    -keyout {{privkey_dst}} -config {{ certconf_tmp }} -batch
+    -keyout {{ privkey_dst }} -config {{ remote_certconf_temp }} -batch
     -newkey rsa:{{ openssl_node.bit_length }}
     -subj '/CN={{openssl_node.name}}'
   args:
@@ -44,31 +56,53 @@
 - name: Pull back the CSR to local machine
   fetch:
     src: "/tmp/{{ csr }}"
-    dest: "{{ openssl_node.local_tmp}}/{{ csr }}"
+    dest: "{{ openssl_node.local_ca_dir }}/csr/{{ csr }}"
     flat: yes
+  tags: fetch
 
-- name: sign csr
+- name: Check for existence of crl list
+  stat:
+    path: "{{ openssl_node.local_ca_dir }}/crl.pem"
+  register: crl_check_result
+  tags: always
+
+- name: Sign CSR using disposable CA environment
   command: >
-    openssl x509 -req -in {{ openssl_node.local_tmp }}/{{ csr }}
-    -CA {{ openssl_node.local_tmp }}/ca_pub_key
-    -CAkey {{ openssl_node.local_tmp }}/ca_priv_key
-    -out {{ openssl_node.local_tmp }}/signed_pub
+    openssl x509 -req -in {{ openssl_node.local_ca_dir }}/csr/{{ csr }}
+    -CA {{ openssl_node.local_ca_dir }}/cacert.pem
+    -CAkey {{ openssl_node.local_ca_dir }}/private/cakey.pem
+    -out {{ openssl_node.local_ca_dir }}/newcerts/{{ openssl_node.name }}.pem
     -set_serial {{ lookup('pipe', "date +'%s'") }}
     -days {{ openssl_node_expiration }} -extensions v3_req
-    -extfile {{ certconf_tmp }} -passin pass:{{ openssl_node_ca_creds }}
+    -extfile {{ openssl_node_conf }} -passin pass:{{ openssl_node_ca_creds }}
   delegate_to: localhost
   args:
-    creates: "{{ openssl_node.local_tmp }}/signed_pub"
+    creates: "{{ openssl_node.local_ca_dir }}/newcerts/{{ openssl_node.name }}.pem"
+    chdir: "{{ openssl_node.local_ca_dir }}"
+  when: not crl_check_result.stat.exists
   become: no
   no_log: true
 
+- name: Sign CSR under static CA environment
+  command: >
+    openssl ca -batch -config {{ openssl_node_conf }}
+    -in {{ openssl_node.local_ca_dir }}/csr/{{ csr }}
+    -out {{ openssl_node.local_ca_dir }}/newcerts/{{ openssl_node.name }}.pem
+    -passin pass:{{ openssl_node_ca_creds }}
+  delegate_to: localhost
+  args:
+    creates: "{{ openssl_node.local_ca_dir }}/newcerts/{{ openssl_node.name }}.pem"
+    chdir: "{{ openssl_node.local_ca_dir }}"
+  when: crl_check_result.stat.exists
+  become: no
+
 - name: Copy over signed cert to destination
   copy:
-    src: "{{ openssl_node.local_tmp }}/signed_pub"
+    src: "{{ openssl_node.local_ca_dir }}/newcerts/{{ openssl_node.name }}.pem"
     dest: "{{ pubkey_dst }}"
 
-- name: Clean-up
-  shell: "shred -u -z {{ openssl_node.local_tmp }}/*"
+- name: Clean-up private CA key
+  shell: "shred -u -z {{ openssl_node.local_ca_dir }}/private/*"
   delegate_to: localhost
   when: openssl_node_ca_destroy
   become: no

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -16,7 +16,7 @@ default_ca	= CA_default		# The default ca section
 ####################################################################
 [ CA_default ]
 
-dir		= ./certs		# Where everything is kept
+dir		= {{ openssl_node.local_ca_dir }}		# Where everything is kept
 certs		= $dir/certs		# Where the issued certs are kept
 crl_dir		= $dir/crl		# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.


### PR DESCRIPTION
Did some tweaking to allow running this role under a persistent CA environment which is necessary to support things like CRL, and serial number tracking.

Previous design was assuming you were storing a CA in ansible vault and
just spinning off CSRs remotely, pulling those back and signing them, then
ignoring the local environment completely (besides private CA key purge).
This was all well and good but does not play nicely with an environment
where you are tracking CA attributes such as serial numbers and MORE
importantly revocation data.

This big commit tries to rework the tasks to allow such a scenario. It
doesn't set that up but if it detects you are trying to run under a
long-running CA folder (by looking for a crl.pem ), a different task will
kick off that will allow you to sign a CSR and also continue track that
data locally.