### PR TITLE
Allow force over-ride of certificate creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .molecule
 .vagrant
+.vscode

--- a/README.md
+++ b/README.md
@@ -24,60 +24,7 @@ openssl_node_certificate_authority:
         asdiaodadiadoaidapodiaodadi
 ```
 
-Here is the rest of the available variables:
-
-```yaml
----
-openssl_node_only_ca: false
-openssl_node_bit_length: 4096
-openssl_node_name: "{{ ansible_fqdn }}"
-openssl_node_expiration: 365
-openssl_node_ca_name: "testca_freedom_press"
-openssl_node_ca_creds: "test_ca"
-
-openssl_node_pub_ca_dir: /usr/local/share/ca-certificates/
-
-# If you are using this role just for cert signing without revocation needs you
-# dont have to maintain those locally and can purge the private key from the
-# system post CSR signature
-openssl_node_ca_destroy: true
-
-openssl_node:
-  name: "{{ openssl_node_name }}"
-  bit_length: "{{ openssl_node_bit_length }}"
-  pub_dst: /etc/ssl/certs
-  priv_dst: /etc/ssl/private
-  local_ca_dir: "./tmp/{{ ansible_fqdn }}"
-
-openssl_node_conf: "{{ openssl_node.local_ca_dir }}/openssl.cnf"
-
-openssl_node_pkgs:
-  - ca-certificates
-  - openssl
-
-openssl_node_ca:
-  use: default_ca_name
-
-openssl_ca_cert_details:
-  city: San Francisco
-  state: CA
-  country: US
-  org: Freedom of the Press Foundation
-  ou: DevOps
-  email: sysadmin@freedom.press
-
-# Swap in your CA cert here and stick in an ansible vault
-openssl_node_certificate_authority:
-  name_of_ca_cert:
-    pub: |
-      [ .............. ]
-    private: |
-      [ .............. ]
-
-openssl_node_ca_cert_sign:
-  ca_pub_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].pub }}"
-  ca_priv_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].private }}"
-```
+See `defaults/main.yml` for available settings.
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -138,3 +138,7 @@ openssl_node_certificate_authority:
 openssl_node_ca_cert_sign:
   ca_pub_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].pub }}"
   ca_priv_key: "{{ openssl_node_certificate_authority[openssl_node_ca_name].private }}"
+
+# Set this to true to force the role to recreate a key. This is normally
+# ill-advised and only to be used if a key has expired.
+openssl_force_resign: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 openssl_node_only_ca: false
 openssl_node_bit_length: 4096
 openssl_node_name: "{{ ansible_fqdn }}"
-openssl_node_expiration: 365
+openssl_node_expiration: 730
 openssl_node_ca_name: "testca_freedom_press"
 openssl_node_ca_creds: "test_ca"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: packages.yml
-  tags: ['packages']
+  tags: ["packages"]
 
 - set_fact:
     privkey_dst: "{{ openssl_node.priv_dst }}/{{ openssl_node.name }}-key.pem"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     - openssl_node_pub_ca_dir == "/usr/local/share/ca-certificates/"
 
 - include: signed-cert.yml
-  when: (not openssl_certs_stat.results[0].stat.exists or
-        not openssl_certs_stat.results[1].stat.exists) and
-        not openssl_node_only_ca
-  tags: ['generate']
+  when: ((not openssl_certs_stat.results[0].stat.exists or
+    not openssl_certs_stat.results[1].stat.exists) and
+    not openssl_node_only_ca ) or openssl_force_resign
+  tags: ["generate"]

--- a/tasks/signed-cert.yml
+++ b/tasks/signed-cert.yml
@@ -38,9 +38,9 @@
     dest: "{{ item.dest }}"
   become: no
   with_items:
-    - key_name: 'ca_pub_key'
+    - key_name: "ca_pub_key"
       dest: "{{ openssl_node.local_ca_dir }}/cacert.pem"
-    - key_name: 'ca_priv_key'
+    - key_name: "ca_priv_key"
       dest: "{{ openssl_node.local_ca_dir }}/private/cakey.pem"
   no_log: true
 

--- a/tasks/signed-cert.yml
+++ b/tasks/signed-cert.yml
@@ -50,8 +50,6 @@
     -keyout {{ privkey_dst }} -config {{ remote_certconf_temp }} -batch
     -newkey rsa:{{ openssl_node.bit_length }}
     -subj '/CN={{openssl_node.name}}'
-  args:
-    creates: "{{ privkey_dst }}"
   register: create_csr
 
 - name: Set private key perms


### PR DESCRIPTION
Two tweaks here:
* Change default expiration of certs from a year to two years
* Allow a varible to force rebuild a certificate (useful for expiring certs or certs you just want to blow away for X reason).

Note that the logic change isn't super smart - it would probably be better to do this in a way that:
* Keeps existing private keys on force flag
* Is smarter about detecting if a cert is expired/expiring and just will automatically run.

I don't have time to do either of those.. soooo you are settling for my mediocre hot-fix!! :tada: